### PR TITLE
feat: use requestAnimationFrame for scheduleChanges

### DIFF
--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -311,18 +311,14 @@ class Minimap {
     this.pendingChangeEvents = this.pendingChangeEvents.concat(changes)
 
     // Optimisation: If the redraw delay is set to 0, do not even schedule a timer
-    if (!this.redrawDelay && !this.requestedFlushChanges) {
-      this.requestedFlushChanges = true
-      requestAnimationFrame(() => { this.flushChanges(); this.requestedFlushChanges = false })
+    if (!this.redrawDelay) {
+      this.requestFlushChanges()
     }
 
-    if (!this.flushChangesTimer && !this.requestedFlushChanges) {
+    if (!this.flushChangesTimer) {
       // If any changes happened within the timeout's delay, a timeout will already have been
       // scheduled -> no need to schedule again
-      this.requestedFlushChanges = true
-      this.flushChangesTimer = setTimeout(
-        () => { requestAnimationFrame(() => { this.flushChanges(); this.requestedFlushChanges = false }) }
-      , this.redrawDelay)
+      this.flushChangesTimer = setTimeout(() => { this.requestFlushChanges() }, this.redrawDelay)
     }
   }
 
@@ -337,6 +333,24 @@ class Minimap {
     this.flushChangesTimer = null
     this.emitChanges(this.pendingChangeEvents)
     this.pendingChangeEvents = []
+  }
+
+  /**
+   * Requests flush changes if not already requested
+   *
+   * @return void
+   * @access private
+   */
+  requestFlushChanges() {
+    if (!this.requestedFlushChanges) {
+      this.requestedFlushChanges = requestAnimationFrame(() => {
+        this.flushChanges();
+        if (this.requestedFlushChanges) {
+          cancelAnimationFrame(this.requestedFlushChanges);
+          this.requestedFlushChanges = null
+        }
+      })
+    }
   }
 
   /**

--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -311,14 +311,18 @@ class Minimap {
     this.pendingChangeEvents = this.pendingChangeEvents.concat(changes)
 
     // Optimisation: If the redraw delay is set to 0, do not even schedule a timer
-    if (!this.redrawDelay) {
-      return this.flushChanges()
+    if (!this.redrawDelay && !this.requestedFlushChanges) {
+      this.requestedFlushChanges = true
+      requestAnimationFrame(() => { this.flushChanges(); this.requestedFlushChanges = false })
     }
 
-    if (!this.flushChangesTimer) {
+    if (!this.flushChangesTimer && !this.requestedFlushChanges) {
       // If any changes happened within the timeout's delay, a timeout will already have been
       // scheduled -> no need to schedule again
-      this.flushChangesTimer = setTimeout(() => { this.flushChanges() }, this.redrawDelay)
+      this.requestedFlushChanges = true
+      this.flushChangesTimer = setTimeout(
+        () => { requestAnimationFrame(() => { this.flushChanges(); this.requestedFlushChanges = false }) }
+      , this.redrawDelay)
     }
   }
 


### PR DESCRIPTION
This allows skipping the frames if the browser is busy doing other things, and it will improve the overall experience

References:
https://blog.teamtreehouse.com/efficient-animations-with-requestanimationframe